### PR TITLE
Fix 'dummy plugin' detection in Morrowind

### DIFF
--- a/src/espfile.cpp
+++ b/src/espfile.cpp
@@ -59,7 +59,7 @@ void ESP::File::init()
               memcpy(&m_TES3Header, &subRec.data()[0], sizeof(m_TES3Header));
             }
             m_Header.version = m_TES3Header.version;
-            // m_Header.numRecords = m_TES3Header.numRecords;
+            m_Header.numRecords = m_TES3Header.numRecords;
             m_Author      = reinterpret_cast<const char*>(m_TES3Header.author);
             m_Description = reinterpret_cast<const char*>(m_TES3Header.description);
             break;


### PR DESCRIPTION
For some reason I had commented out this code when I added the Morrowind parsing years ago, but I have no idea why and it seems to fix the issue.

I can't see an obvious issue with this being uncommented.